### PR TITLE
Update isolinux.cfg

### DIFF
--- a/iso/isolinux.cfg
+++ b/iso/isolinux.cfg
@@ -9,15 +9,16 @@ label Whonix Desktop Live VM Live
 menu label ^Whonix Desktop Live VM Live
 menu default
 kernel /live/vmlinuz
-append initrd=/live/initrd boot=live live-config.user-default-groups=libvirt,kvm apparmor=1 security=apparmor ip=frommedia
+append initrd=/live/initrd boot=live spectre_v2=on spec_store_bypass_disable=on tsx=off tsx_async_abort=full,nosmt mds=full,nosmt l1tf=full,force nosmt=force kvm.nx_huge_pages=force random.trust_cpu=off intel_iommu=on amd_iommu=on efi=disable_early_pci_dma slab_nomerge slub_debug=FZP page_poison=1 mce=0 pti=on vsyscall=none extra_latent_entropy
 text help
    Boot Whonix Desktop Live VM Live image
 endtext
 
 label Whonix Desktop Live VM Live Quiet
 menu label ^Whonix Desktop Live VM Live (Quiet / Silent Boot)
+menu default
 kernel /live/vmlinuz
-append initrd=/live/initrd boot=live live-config.user-default-groups=libvirt,kvm apparmor=1 security=apparmor ip=frommedia
+append initrd=/live/initrd boot=live spectre_v2=on spec_store_bypass_disable=on tsx=off tsx_async_abort=full,nosmt mds=full,nosmt l1tf=full,force nosmt=force kvm.nx_huge_pages=force random.trust_cpu=off intel_iommu=on amd_iommu=on efi=disable_early_pci_dma slab_nomerge slub_debug=FZP page_poison=1 mce=0 pti=on vsyscall=none extra_latent_entropy quiet
 text help
    Boot Whonix Desktop Live VM Live image with the quiet flag to hide kernel messages
 endtext


### PR DESCRIPTION
Update isolinux.cfg to mirror default kernel boot flags used in Kicksecure. Removal of ip=frommedia, live-config.user-default-groups=libvirt,kvm, and apparmor=1 security=apparmor options. See https://forums.whonix.org/t/whonix-host-operating-system/3931/153