### PR TITLE
Update isolinux.cfg

### DIFF
--- a/iso/isolinux.cfg
+++ b/iso/isolinux.cfg
@@ -5,22 +5,22 @@ menu title Boot Menu
 
 timeout 30
 
-label Whonix Desktop Live VM Live
-menu label ^Whonix Desktop Live VM Live
+label Whonix-Host Live
+menu label ^Whonix-Host Live
 menu default
 kernel /live/vmlinuz
 append initrd=/live/initrd boot=live spectre_v2=on spec_store_bypass_disable=on tsx=off tsx_async_abort=full,nosmt mds=full,nosmt l1tf=full,force nosmt=force kvm.nx_huge_pages=force random.trust_cpu=off intel_iommu=on amd_iommu=on efi=disable_early_pci_dma slab_nomerge slub_debug=FZP page_poison=1 mce=0 pti=on vsyscall=none extra_latent_entropy
 text help
-   Boot Whonix Desktop Live VM Live image
+   Boot Whonix-Host Live
 endtext
 
-label Whonix Desktop Live VM Live Quiet
-menu label ^Whonix Desktop Live VM Live (Quiet / Silent Boot)
+label Whonix-Host Live Quiet
+menu label ^Whonix-Host Live (Quiet / Silent Boot)
 menu default
 kernel /live/vmlinuz
 append initrd=/live/initrd boot=live spectre_v2=on spec_store_bypass_disable=on tsx=off tsx_async_abort=full,nosmt mds=full,nosmt l1tf=full,force nosmt=force kvm.nx_huge_pages=force random.trust_cpu=off intel_iommu=on amd_iommu=on efi=disable_early_pci_dma slab_nomerge slub_debug=FZP page_poison=1 mce=0 pti=on vsyscall=none extra_latent_entropy quiet
 text help
-   Boot Whonix Desktop Live VM Live image with the quiet flag to hide kernel messages
+   Boot Whonix-Host Live with the quiet flag to hide kernel messages
 endtext
 
 label hdt


### PR DESCRIPTION
Replacing "Whonix Desktop" by "Whonix-Host", suppressing redundant words (label/menu). See https://forums.whonix.org/t/whonix-host-operating-system/3931/201