### PR TITLE
Update 1800_copy_vms_into_raw

### DIFF
--- a/build-steps.d/1800_copy_vms_into_raw
+++ b/build-steps.d/1800_copy_vms_into_raw
@@ -35,8 +35,8 @@ copy-vm-files(){
    #cp --sparse=always "$copy_vms_into_raw_file_two" "$CHROOT_FOLDER/var/lib/libvirt/images/Whonix-Workstation.qcow2"
 
    ## Therefore using qemu-img.
-   qemu-img convert -f raw -O qcow2 "$copy_vms_into_raw_file_one" "$CHROOT_FOLDER/var/lib/libvirt/images/Whonix-Gateway.qcow2"
-   qemu-img convert -f raw -O qcow2 "$copy_vms_into_raw_file_two" "$CHROOT_FOLDER/var/lib/libvirt/images/Whonix-Workstation.qcow2"
+   qemu-img convert -f qcow2 -O qcow2 "$copy_vms_into_raw_file_one" "$CHROOT_FOLDER/var/lib/libvirt/images/Whonix-Gateway.qcow2"
+   qemu-img convert -f qcow2 -O qcow2 "$copy_vms_into_raw_file_two" "$CHROOT_FOLDER/var/lib/libvirt/images/Whonix-Workstation.qcow2"
 
    ## TODO: qemu-img parameters?
 #    qemu-img \


### PR DESCRIPTION
Changing -f raw to -f qcow2 since the disk images are already qcow2 files. Fixes "Boot failed: not a bootable disk" error. See https://forums.whonix.org/t/whonix-host-operating-system/3931/210