### PR TITLE
Preliminary Mac M1 arm64 support

### DIFF
--- a/build-steps.d/1300_create-raw-image
+++ b/build-steps.d/1300_create-raw-image
@@ -110,7 +110,7 @@ create-debian-raw-image() {
 
    mmdebstrap_wrapper="$WHONIX_SOURCE_FOLDER/help-steps/pbuilder-debootstrap-command-filter"
 
-   if [ "$WHONIX_BUILD_FLAVOR" = "whonix-gateway-rpi" ]; then
+   if [ "$WHONIX_BUILD_FLAVOR" = "whonix-gateway-rpi" ] || [ "$BUILD_TARGET_ARCH" = "arm64" ]; then
       [ -n "$GRUB_INSTALL" ] || export GRUB_INSTALL='no'
    fi
 

--- a/build-steps.d/1700_install-packages
+++ b/build-steps.d/1700_install-packages
@@ -310,6 +310,11 @@ $whonix_build_script_skip_package_install${reset}"
       fi
    fi
 
+   if [ "$WHONIX_BUILD_FLAVOR" != "whonix-gateway-rpi" ] && [ "$BUILD_TARGET_ARCH" = "arm64" ]; then
+      pkg-add-to-install-list grub2-common
+      pkg-add-to-install-list grub-efi-arm64
+   fi
+
    ## Weak recommended packages. No other package depends on it. Can be
    ## easily uninstalled. For better usability.
    if [ "$WHONIX_BUILD_VIRTUALBOX" = "true" ]; then

--- a/build-steps.d/2376_build_arm64_fs
+++ b/build-steps.d/2376_build_arm64_fs
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+## Copyright (C) 2012 - 2021 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## Copyright (C) 2021 Gavin Pacini
+## See the file COPYING for copying conditions.
+
+set -x
+set -e
+
+true "INFO: Currently running script: $BASH_SOURCE $@"
+
+MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd "$MYDIR"
+cd ..
+cd help-steps
+
+source pre
+source colors
+source variables
+
+build_arm64_fs() {
+   source "$WHONIX_SOURCE_HELP_STEPS_FOLDER"/mount-raw
+
+   ## create a copy of the raw output,
+   ## such that we can make a new one with grub on an EFI partition
+   ## along with mount points
+   orig_img = "${binary_image_raw}.orig"
+   mpoint_os = "${binary_image_raw}_mpoint_os"
+   mpoint_efi = "${mpoint_os}/boot/efi"
+   cp $binary_image_raw $orig_img
+
+   ## provides: dev_mapper_device
+   export WHONIX_BUILD_MOUNT_RAW_FILE="$orig_img"
+   mount_raw
+
+   ## creating the image
+   sudo $SUDO_OPTS truncate -s $VMSIZE $binary_image_raw
+   sudo $SUDO_OPTS mkdir --parents $mpoint_os
+
+   ## partitioning
+   dev=$(losetup -f)
+   losetup "$dev" $binary_image_raw
+   parted -s "$dev" mklabel gpt
+   parted -s "$dev" unit s mkpart EFI fat32 -- 1 524280
+   parted -s "$dev" set 1 boot on
+   parted -s "$dev" unit s mkpart LINUX ext4 -- 524281 -1
+   mkfs.vfat -n EFI "${dev}p1"
+   mkfs.ext4 -F -L LINUX "${dev}p2"
+   parted -s "$dev" print
+
+   ## copying OS files
+   mount "${dev}p2" "${mpoint_os}"
+   cp -a "$CHROOT_FOLDER"/* "${mpoint_os}"
+   sync
+
+   ## setup arm64 grub on EFI partition
+   sudo $SUDO_OPTS mkdir --parents $mpoint_efi
+   mount "${dev}p1" "${mpoint_efi}"
+
+   mount --bind /dev "${mpoint_os}/dev"
+   mount -t devpts /dev/pts "${mpoint_os}/dev/pts"
+   mount -t proc proc "${mpoint_os}/proc"
+   mount -t sysfs sysfs "${mpoint_os}/sys"
+   mount -t tmpfs tmpfs "${mpoint_os}/tmp"
+
+   chroot $mpoint_os grub-install --target=arm64-efi --efi-directory=/boot/efi --bootloader-id=debian --recheck --no-nvram --removable
+   chroot $mpoint_os update-grub
+   chroot $mpoint_os sync
+   sync
+   sleep 2
+
+   umount "${mpoint_os}/dev/pts"
+   umount "${mpoint_os}/dev"
+   umount "${mpoint_os}/proc"
+   umount "${mpoint_os}/sys"
+   umount "${mpoint_os}/tmp"
+   umount "${mpoint_efi}"
+   umount "${mpoint_os}"
+
+   losetup -d "$dev"
+
+   rmdir "${mpoint_os}"
+
+   export WHONIX_BUILD_MOUNT_RAW_FILE="$orig_img"
+   "$WHONIX_SOURCE_HELP_STEPS_FOLDER"/unmount-raw
+
+   rm $orig_img
+}
+
+main() {
+   root_check
+   if [ "$WHONIX_BUILD_FLAVOR" != "whonix-gateway-rpi" ] && [ "$BUILD_TARGET_ARCH" = "arm64" ]; then
+      build_arm64_fs
+   else
+      true "${green}INFO: Skipping $BASH_SOURCE, because not building standard arm64.${reset}"
+   fi
+}
+
+main "$@"

--- a/build-steps.d/2376_build_arm64_fs
+++ b/build-steps.d/2376_build_arm64_fs
@@ -25,9 +25,9 @@ build_arm64_fs() {
    ## create a copy of the raw output,
    ## such that we can make a new one with grub on an EFI partition
    ## along with mount points
-   orig_img = "${binary_image_raw}.orig"
-   mpoint_os = "${binary_image_raw}_mpoint_os"
-   mpoint_efi = "${mpoint_os}/boot/efi"
+   orig_img="${binary_image_raw}.orig"
+   mpoint_os="${binary_image_raw}_mpoint_os"
+   mpoint_efi="${mpoint_os}/boot/efi"
    cp $binary_image_raw $orig_img
 
    ## provides: dev_mapper_device
@@ -42,9 +42,9 @@ build_arm64_fs() {
    dev=$(losetup -f)
    losetup "$dev" $binary_image_raw
    parted -s "$dev" mklabel gpt
-   parted -s "$dev" unit s mkpart EFI fat32 -- 1 524280
+   parted -s "$dev" mkpart EFI fat32 1MiB 10MiB 
    parted -s "$dev" set 1 boot on
-   parted -s "$dev" unit s mkpart LINUX ext4 -- 524281 -1
+   parted -s "$dev" mkpart LINUX ext4 10MiB 100%
    mkfs.vfat -n EFI "${dev}p1"
    mkfs.ext4 -F -L LINUX "${dev}p2"
    parted -s "$dev" print
@@ -55,7 +55,7 @@ build_arm64_fs() {
    sync
 
    ## setup arm64 grub on EFI partition
-   sudo $SUDO_OPTS mkdir --parents $mpoint_efi
+   mkdir --parents $mpoint_efi
    mount "${dev}p1" "${mpoint_efi}"
 
    mount --bind /dev "${mpoint_os}/dev"

--- a/build-steps.d/2376_build_arm64_fs
+++ b/build-steps.d/2376_build_arm64_fs
@@ -28,19 +28,19 @@ build_arm64_fs() {
    orig_img="${binary_image_raw}.orig"
    mpoint_os="${binary_image_raw}_mpoint_os"
    mpoint_efi="${mpoint_os}/boot/efi"
-   cp $binary_image_raw $orig_img
+   cp "$binary_image_raw" "$orig_img"
 
    ## provides: dev_mapper_device
    export WHONIX_BUILD_MOUNT_RAW_FILE="$orig_img"
    mount_raw
 
    ## creating the image
-   sudo $SUDO_OPTS truncate -s $VMSIZE $binary_image_raw
-   sudo $SUDO_OPTS mkdir --parents $mpoint_os
+   sudo $SUDO_OPTS truncate -s "$VMSIZE" "$binary_image_raw"
+   sudo $SUDO_OPTS mkdir --parents "$mpoint_os"
 
    ## partitioning
    dev=$(losetup -f)
-   losetup "$dev" $binary_image_raw
+   losetup "$dev" "$binary_image_raw"
    parted -s "$dev" mklabel gpt
    parted -s "$dev" mkpart EFI fat32 1MiB 10MiB 
    parted -s "$dev" set 1 boot on
@@ -55,7 +55,7 @@ build_arm64_fs() {
    sync
 
    ## setup arm64 grub on EFI partition
-   mkdir --parents $mpoint_efi
+   mkdir --parents "$mpoint_efi"
    mount "${dev}p1" "${mpoint_efi}"
 
    mount --bind /dev "${mpoint_os}/dev"
@@ -64,12 +64,13 @@ build_arm64_fs() {
    mount -t sysfs sysfs "${mpoint_os}/sys"
    mount -t tmpfs tmpfs "${mpoint_os}/tmp"
 
-   chroot $mpoint_os grub-install --target=arm64-efi --efi-directory=/boot/efi --bootloader-id=debian --recheck --no-nvram --removable
-   chroot $mpoint_os update-grub
-   chroot $mpoint_os sync
+   chroot "$mpoint_os" grub-install --target=arm64-efi --efi-directory=/boot/efi --bootloader-id=debian --recheck --no-nvram --removable
+   chroot "$mpoint_os" update-grub
+   chroot "$mpoint_os" sync
    sync
    sleep 2
 
+   ## unmount all the things
    umount "${mpoint_os}/dev/pts"
    umount "${mpoint_os}/dev"
    umount "${mpoint_os}/proc"
@@ -85,7 +86,8 @@ build_arm64_fs() {
    export WHONIX_BUILD_MOUNT_RAW_FILE="$orig_img"
    "$WHONIX_SOURCE_HELP_STEPS_FOLDER"/unmount-raw
 
-   rm $orig_img
+   ## remove the original image which did not have GRUB nor EFI partitions
+   rm "$orig_img"
 }
 
 main() {

--- a/help-steps/parse-cmd
+++ b/help-steps/parse-cmd
@@ -629,6 +629,9 @@ whonix_build_one_parse_cmd() {
    if [ "$BUILD_TARGET_ARCH" = "i386" ]; then
       [ -n "$BUILD_KERNEL_PKGS" ] || BUILD_KERNEL_PKGS="linux-image-686"
       [ -n "$BUILD_HEADER_PKGS" ] || BUILD_HEADER_PKGS="linux-headers-686"
+   elif [ "$BUILD_TARGET_ARCH" = "arm64" ]; then
+      [ -n "$BUILD_KERNEL_PKGS" ] || BUILD_KERNEL_PKGS="linux-image-arm64"
+      [ -n "$BUILD_HEADER_PKGS" ] || BUILD_HEADER_PKGS="linux-headers-arm64"
    fi
 
    [ -n "$BUILD_TARGET_ARCH" ] || BUILD_TARGET_ARCH="amd64"


### PR DESCRIPTION
Opening this PR while it's still in progress just so we can start the review process, and also in case anyone else wants to tinker.

Currently, this builds valid arm64 images, which can be run via QEMU ([using certain patches which are not upstream yet](https://github.com/knazarov/homebrew-qemu-virgl)) on a Mac M1 (and probably other arm64 chips which I expect we'll see more of).

`sudo ./whonix_build --target raw --flavor whonix-workstation-xfce --build --arch arm64 --allow-untagged true`
`sudo ./whonix_build --target raw --flavor whonix-gateway-xfce --build --arch arm64 --allow-untagged true`

Please see this forum thread for further context: https://forums.whonix.org/t/whonix-on-mac-with-arm-m1/11310